### PR TITLE
jh7100-recover:Improve the result checking mechanism and message display

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@
 PROG_NAME=jh7100-recover
 
 CFLAGS := -Wall
+
+#if you need to enable debug info, just uncomment below
+#CFLAGS += -DDEBUG
+
 EXEF := $(PROG_NAME)
 
 .PHONY : all clean

--- a/recover_dev.sh
+++ b/recover_dev.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+#title		:recover_dev.sh
+#description	:This script will help to execute jh7100-recover.
+#author	:TekkamanV <tekkamanv@163.com>
+#date		:202107013
+#version	:0.1
+#usage		:./recover_dev.sh [tty_device_name]
+#		default UART port is /dev/ttyUSB0, you can set up it by ${1},
+#		like, ./recover_dev.sh ttyUSB1
+#SPDX-License-Identifier: GNU General Public License v2.0 or later
+#==============================================================================
+
+PROG_NAME=jh7100-recover
+
+UART_PORT=/dev/${1:-ttyUSB0}
+
+PREBUILD_PATH=./prebuild
+RECOVERY_PATH=${PREBUILD_PATH}/JH7100_recovery_boot.bin
+DDRINIT_PATH=${PREBUILD_PATH}/ddrinit-*.bin.out
+BOOTLOADER_PATH=${PREBUILD_PATH}/bootloader-BEAGLEV-*.bin.out
+
+./${PROG_NAME} \
+	-D ${UART_PORT} \
+	-r ${RECOVERY_PATH} \
+	-b ${BOOTLOADER_PATH} \
+	-d ${DDRINIT_PATH}
+


### PR DESCRIPTION
Improve the result checking mechanism: from string length to string 

message display:
```
Waiting for bootloader mode on /dev/ttyUSB0...
Bootloader mode active

Uploading recovery binary...
	Waiting for XMODEM request[C]...
	Sending ./prebuild/JH7100_recovery_boot.bin 
[########################################] 100%  24081/24081 Bytes

----------Enter recovery mode----------
Updating bootloader...
	Waiting for XMODEM request[C]...
	Sending ./prebuild/bootloader-BEAGLEV-210607.bin.out 
[########################################] 100%  9416/9416 Bytes
Awaiting confirmation...
done.

Updating dduinit...
	Waiting for XMODEM request[C]...
	Sending ./prebuild/ddrinit-2133-210607.bin.out 
[########################################] 100%  87500/87500 Bytes
Awaiting confirmation...
done.


Firmware update completed!
```

Signed-off-by: TekkamanV <tekkamanv@163.com>