### PR TITLE
jh7100-recover: Use int for getopt return value

### DIFF
--- a/jh7100-recover.c
+++ b/jh7100-recover.c
@@ -401,7 +401,8 @@ static const struct option long_options[] = {
 
 int main(int argc, char **argv)
 {
-	char c, *recovery_f = NULL, *bootloader_f = NULL, *ddr_init_f = NULL;
+	char *recovery_f = NULL, *bootloader_f = NULL, *ddr_init_f = NULL;
+	int c;
 
 	progname = argv[0];
 


### PR DESCRIPTION
The type char is signed on some platforms and unsigned on others and the
current code does not work on unsigned-char platforms. Change type of
`c` to int to match actual return type of getopt and avoid this issue.
